### PR TITLE
Refactor code: Replace deprecated @import with @use directive

### DIFF
--- a/src/assets/scss/_main.scss
+++ b/src/assets/scss/_main.scss
@@ -1,6 +1,6 @@
 /** Components **/
-@import 'base/typography';
+@use 'base/typography';
 
 /** Components **/
-@import 'components/personal-info-dialog';
-@import 'components/personal-info-form';
+@use 'components/personal-info-dialog';
+@use 'components/personal-info-form';


### PR DESCRIPTION
The @import directive has been removed from the latest version, and @use is now the recommended approach for importing stylesheets